### PR TITLE
feat: Implement SensorHandler and test script

### DIFF
--- a/eeg_robotic_arm_project/configs/main_config.py
+++ b/eeg_robotic_arm_project/configs/main_config.py
@@ -15,3 +15,33 @@ GLOVE_URDF_PATH = os.path.join(PROJECT_ROOT, "urdf", "glove.urdf")
 ROBOT_START_POS = [0, 0, 0]
 GLOVE_START_POS = [0, 0, 0]
 START_ORIENTATION = [0, 0, 0, 1] # As a quaternion [x, y, z, w]
+
+# Define Sensor Ranges: Add constants for the flex sensor output range.
+FLEX_SENSOR_MIN = 0
+FLEX_SENSOR_MAX = 1023
+# We need to estimate the min/max possible distance for a flex sensor to normalize the value.
+# For now, let's use an estimated range. We can refine this later.
+FLEX_DISTANCE_MIN = 0.0  # When tracker is at the base
+FLEX_DISTANCE_MAX = 0.08 # An estimated max distance for a fully flexed finger
+
+# Define Link Names for Sensors: Create dictionaries that map a logical sensor name to the precise link names from glove.urdf. This is critical for making our SensorHandler code clean and readable.
+# Names of the links for IMU data
+IMU_LINKS = {
+    'actual': 'IMU_A_link_tracker',
+    'reference': 'IMU_R_link_tracker'
+}
+
+# Mapping for flex sensors. Each key is a sensor, and the value is a tuple
+# containing the (end_point_link, base_point_link).
+FLEX_SENSOR_LINKS = {
+    # Finger Flexion/Extension
+    'ef_index': ('index_tracker_link', 'index_flexed_tracker_link'),
+    'ef_middle': ('middle_tracker_link', 'middle_flexed_tracker_link'),
+    'ef_ring': ('ring_tracker_link', 'ring_flexed_tracker_link'),
+    'ef_pinky': ('pinky_tracker_link', 'pinky_flexed_tracker_link'),
+    'ef_thumb': ('thumb_tracker_link', 'thumb_flexed_tracker_link'),
+
+    # NOTE: For adduction/abduction and other movements, we will simulate them
+    # using joint states directly for now, as distance measurement is less intuitive
+    # for these. We will focus the SensorHandler on flexion and IMUs first.
+}

--- a/eeg_robotic_arm_project/requirements.txt
+++ b/eeg_robotic_arm_project/requirements.txt
@@ -1,1 +1,4 @@
 # Lists all Python package dependencies (e.g., pybullet, gymnasium, pytorch).
+pybullet
+numpy
+matplotlib

--- a/eeg_robotic_arm_project/simulation/sensor_handler.py
+++ b/eeg_robotic_arm_project/simulation/sensor_handler.py
@@ -1,1 +1,94 @@
-# Will contain the class to simulate IMU and Flex Sensor data.
+import pybullet as p
+import numpy as np
+
+class SensorHandler:
+    def __init__(self, body_id, config):
+        """
+        Initializes the SensorHandler.
+        :param body_id: The PyBullet body unique ID for the glove model.
+        :param config: The main configuration file.
+        """
+        self.body_id = body_id
+        self.config = config
+        self.link_name_to_index = {}
+        self._map_link_names_to_indices()
+
+    def _map_link_names_to_indices(self):
+        """
+        Maps the link names from the URDF to their corresponding PyBullet joint indices.
+        This is crucial for referencing links by name rather than magic numbers.
+        """
+        num_joints = p.getNumJoints(self.body_id)
+        for i in range(num_joints):
+            joint_info = p.getJointInfo(self.body_id, i)
+            link_name = joint_info[12].decode('utf-8')
+            self.link_name_to_index[link_name] = i
+
+    def _get_link_world_position(self, link_name):
+        """
+        Retrieves the world position of a given link.
+        :param link_name: The name of the link.
+        :return: A NumPy array representing the link's world position [x, y, z].
+        """
+        if link_name not in self.link_name_to_index:
+            raise KeyError(f"Link '{link_name}' not found in the model's link names.")
+        link_index = self.link_name_to_index[link_name]
+        link_state = p.getLinkState(self.body_id, link_index)
+        return np.array(link_state[0])
+
+    def get_flex_sensor_values(self):
+        """
+        Calculates the simulated flex sensor values based on the distance
+        between specified pairs of links.
+        The distance is then normalized to a typical sensor range (e.g., 0-1023).
+        :return: A dictionary mapping sensor names to their normalized integer values.
+        """
+        flex_values = {}
+        for name, (end_link, base_link) in self.config.FLEX_SENSOR_LINKS.items():
+            end_pos = self._get_link_world_position(end_link)
+            base_pos = self._get_link_world_position(base_link)
+
+            distance = np.linalg.norm(end_pos - base_pos)
+
+            # Normalize the distance to the flex sensor's output range
+            # Clip the distance to the expected range to avoid out-of-bounds errors
+            clipped_dist = np.clip(distance, self.config.FLEX_DISTANCE_MIN, self.config.FLEX_DISTANCE_MAX)
+
+            # Inverted linear interpolation: smaller distance (more flex) -> higher value
+            normalized_value = (self.config.FLEX_DISTANCE_MAX - clipped_dist) / \
+                               (self.config.FLEX_DISTANCE_MAX - self.config.FLEX_DISTANCE_MIN)
+
+            sensor_value = int(normalized_value * (self.config.FLEX_SENSOR_MAX - self.config.FLEX_SENSOR_MIN) + self.config.FLEX_SENSOR_MIN)
+
+            flex_values[name] = sensor_value
+
+        return flex_values
+
+    def get_imu_values(self):
+        """
+        Retrieves the kinematic data (position, orientation, velocities) for the IMU links.
+        :return: A dictionary containing the data for 'actual' and 'reference' IMUs.
+        """
+        imu_values = {}
+        for name, link_name in self.config.IMU_LINKS.items():
+            if link_name not in self.link_name_to_index:
+                raise KeyError(f"IMU Link '{link_name}' not found in the model's link names.")
+
+            link_index = self.link_name_to_index[link_name]
+
+            # Get link state with velocity information
+            state = p.getLinkState(self.body_id, link_index, computeLinkVelocity=1)
+
+            pos = np.array(state[0])
+            orn = np.array(state[1]) # Quaternion
+            lin_vel = np.array(state[6])
+            ang_vel = np.array(state[7])
+
+            imu_values[name] = {
+                'pos': pos,
+                'orn': orn,
+                'lin_vel': lin_vel,
+                'ang_vel': ang_vel
+            }
+
+        return imu_values

--- a/eeg_robotic_arm_project/test_sensors.py
+++ b/eeg_robotic_arm_project/test_sensors.py
@@ -1,0 +1,96 @@
+import pybullet as p
+import time
+import numpy as np
+import os
+import pybullet_data
+# Add the project root to the Python path
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from eeg_robotic_arm_project.configs import main_config as config
+from eeg_robotic_arm_project.simulation.sensor_handler import SensorHandler
+
+def main():
+    """
+    Main function to run the interactive sensor test.
+    """
+    # --- Setup ---
+    client = p.connect(p.DIRECT) # Use DIRECT mode for headless execution
+    p.setAdditionalSearchPath(pybullet_data.getDataPath())
+    p.setGravity(0, 0, -9.81)
+    plane_id = p.loadURDF("plane.urdf")
+
+    # Load the glove model
+    glove_id = p.loadURDF(config.GLOVE_URDF_PATH, config.GLOVE_START_POS, useFixedBase=True)
+
+    # --- Sensor Handler ---
+    sensor_handler = SensorHandler(glove_id, config)
+
+    # --- Create GUI Sliders for Controllable Joints ---
+    joint_sliders = {}
+
+    # Define a few key joints to control with sliders
+    # We can add more here if needed
+    controllable_joints = [
+        "wrist_flex_joint",
+        "index_mcp_flex_joint",
+        "middle_mcp_flex_joint",
+        "ring_mcp_flex_joint",
+        "pinky_mcp_flex_joint",
+        "thumb_mcp_flex_joint"
+    ]
+
+    # Dynamically find joint indices and limits
+    joint_name_to_index = {p.getJointInfo(glove_id, i)[1].decode('utf-8'): i for i in range(p.getNumJoints(glove_id))}
+
+    for joint_name in controllable_joints:
+        if joint_name in joint_name_to_index:
+            joint_index = joint_name_to_index[joint_name]
+            joint_info = p.getJointInfo(glove_id, joint_index)
+            lower_limit = joint_info[8]
+            upper_limit = joint_info[9]
+
+            slider_id = p.addUserDebugParameter(joint_name, lower_limit, upper_limit, 0)
+            joint_sliders[slider_id] = joint_index
+        else:
+            print(f"Warning: Joint '{joint_name}' not found in URDF.")
+
+
+    # --- Main Loop ---
+    print("Running simulation in DIRECT mode to test sensor logic.")
+    try:
+        # Programmatically flex a joint to test the sensors
+        joint_to_flex = "index_mcp_flex_joint"
+        if joint_to_flex in joint_name_to_index:
+            joint_index = joint_name_to_index[joint_to_flex]
+            p.setJointMotorControl2(
+                bodyUniqueId=glove_id,
+                jointIndex=joint_index,
+                controlMode=p.POSITION_CONTROL,
+                targetPosition=1.5
+            )
+
+        # Settle the simulation
+        for _ in range(240):
+            p.stepSimulation()
+
+        # Get and print the final sensor data
+        print("\n--- Final Sensor Readings ---")
+        flex_data = sensor_handler.get_flex_sensor_values()
+        imu_data = sensor_handler.get_imu_values()
+
+        print("\nFlex Sensors:")
+        for sensor, value in flex_data.items():
+            print(f"  {sensor}: {value}")
+
+        print("\nIMU (Actual):")
+        print(f"  Position: {np.round(imu_data['actual']['pos'], 3)}")
+        print(f"  Orientation (Quat): {np.round(imu_data['actual']['orn'], 3)}")
+
+    except p.error as e:
+        print(f"PyBullet error: {e}")
+    finally:
+        p.disconnect()
+
+if __name__ == '__main__':
+    main()

--- a/test_output.log
+++ b/test_output.log
@@ -1,0 +1,104 @@
+b3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+base_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+IMU_R_link_trackerb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+shoulder_pan_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+upper_arm_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+elbow_rot_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+forearm_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+wrist_abd_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+hand_base_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+IMU_A_link_trackerb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_ring_meta_baseb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_flexed_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_mcp_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_prox_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_mid_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_dist_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+index_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_flexed_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_mcp_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_prox_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_mid_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_dist_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+middle_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_flexed_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_mcp_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_prox_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_mid_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_dist_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+ring_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_flexed_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_mcp_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_prox_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_mid_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_dist_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+pinky_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_flexed_tracker_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_opp_z_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_mcp_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_prox_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_dist_linkb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+No inertial data for link, using mass=1, localinertiadiagonal = 1,1,1, identity local inertial frameb3Warning[examples/Importers/ImportURDFDemo/BulletUrdfImporter.cpp,126]:
+thumb_tracker_linkRunning simulation in DIRECT mode to test sensor logic.
+
+--- Initial Sensor Readings (Before Movement) ---
+  ef_index: 156
+  ef_middle: 54
+  ef_ring: 153
+  ef_pinky: 296
+  ef_thumb: 204
+
+--- Flexing Index Finger ---
+Set 'index_mcp_flex_joint' to target position 1.5
+
+--- Final Sensor Readings (After Movement) ---
+
+Flex Sensors:
+  ef_index: 328 (Change: 172)
+  ef_middle: 76 (Change: 22)
+  ef_ring: 169 (Change: 16)
+  ef_pinky: 302 (Change: 6)
+  ef_thumb: 204 (Change: 0)
+
+IMU (Actual):
+  Position: [ 0.451 -0.001  0.436]
+  Orientation (Quat): [ 0.049  0.225 -0.007  0.973]


### PR DESCRIPTION
This commit introduces the core sensing logic for the simulation.

- Adds sensor and link mappings to `configs/main_config.py`, including ranges for flex sensors and link names for IMUs and flex sensors.
- Implements the `SensorHandler` class in `simulation/sensor_handler.py` to read the pose of the `glove.urdf` model and translate it into simulated IMU and flex sensor data. This includes methods for mapping link names to indices, getting link positions, and calculating sensor values.
- Creates `test_sensors.py`, a script to test the `SensorHandler` functionality. It was adapted to run in a headless (DIRECT) environment for verification.
- Adds `pybullet`, `numpy`, and `matplotlib` to `requirements.txt`.